### PR TITLE
Fixed url token issue

### DIFF
--- a/src/pages/CountryDetail/CountryDetail.js
+++ b/src/pages/CountryDetail/CountryDetail.js
@@ -15,7 +15,7 @@ const axios = require("axios");
 function CountryDetail({ match, history }) {
   let API_URL;
   const FILTER_PARAMS =
-    "?fields=name;flag;nativeName;population;region;subregion;capital;topLevelDomain;currencies;languages;borders";
+    "fields=name;flag;nativeName;population;region;subregion;capital;topLevelDomain;currencies;languages;borders";
 
   const [country, setCountryData] = useState({});
   const [error, setError] = useState(false);
@@ -24,9 +24,9 @@ function CountryDetail({ match, history }) {
 
   // Check if countryName is a 2-letter or 3-letter country code
   if (/^[A-Z]{2,3}/.test(countryName)) {
-    API_URL = `https://restcountries.eu/rest/v2/alpha?codes=${countryName};${FILTER_PARAMS}`;
+    API_URL = `https://restcountries.eu/rest/v2/alpha?codes=${countryName}&${FILTER_PARAMS}`;
   } else {
-    API_URL = `https://restcountries.eu/rest/v2/name/${countryName}?fullText=true${FILTER_PARAMS}`;
+    API_URL = `https://restcountries.eu/rest/v2/name/${countryName}?fullText=true&${FILTER_PARAMS}`;
   }
 
   useEffect(() => {


### PR DESCRIPTION
fix for issue #3

REST api call to fecth countries has two **?** that gives unexpected result.

### **Reproduce:** 
**step 1:**
open chrome dev tool

**step 2:**
go to [Afghanistan](https://srd-whereintheworld.netlify.com/country/Afghanistan)

**step 3:** 
check the ajax url made to fecth country details

**response:**
`https://restcountries.eu/rest/v2/name/Afghanistan?fullText=true?fields=name;flag;nativeName;population;region;subregion;capital;topLevelDomain;currencies;languages;borders`

It has the symbol **?** twice, which gives us two issues

**issue 1:** while we expect only the requested fields from rest api, it returns all the fields

**issue 2:** If you click the country [India](https://srd-whereintheworld.netlify.com/country/India) we get the reponse of **British Indian Ocean Territory** not India that is because of the wrong url
